### PR TITLE
Make consistent with main website

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,21 +47,25 @@
         </div>
 
 
-        <div id="navigation">
+        <div id="primary-navigation">
+            <ul>
+                <li><a href="https://www.macports.org/index.php" title="Home">Home</a></li>
+                <li><a href="https://www.macports.org/install.php" title="Installing MacPorts">Installing MacPorts</a></li>
+                <li><a href="https://www.macports.org/ports.php" title="Available Ports">Available Ports</a></li>
+                <li><a href="https://guide.macports.org/" title="Documentation">Documentation</a></li>
+                <li><a href="https://trac.macports.org/" title="Support &amp; Development">Support &amp; Development</a></li>
+                <li><a href="https://www.macports.org/contact.php" title="Contact Us">Contact Us</a></li>
+                <li class="active"><a href="https://www.macports.org/news/" title="News">News</a></li>
+            </ul>
+        </div>
+
+        <div class="full-width-border">
+        </div>
+        <br>
+
+        <div id="side-navigation">
 
             <dl>
-                <dt>Getting Started</dt>
-                <dd>
-                    <ul>
-<li><a href="https://www.macports.org/index.php" title="Home">Home</a></li>
-<li><a href="https://www.macports.org/install.php" title="Installing MacPorts">Installing MacPorts</a></li>
-<li><a href="https://www.macports.org/ports.php" title="Available Ports">Available Ports</a></li>
-<li><a href="https://guide.macports.org/" title="Documentation">Documentation</a></li>
-<li><a href="https://trac.macports.org/" title="Support &amp; Development">Support &amp; Development</a></li>
-<li><a href="https://www.macports.org/contact.php" title="Contact Us">Contact Us</a></li>
-<li class="selected"><a href="https://www.macports.org/news/" title="News">News</a></li>
-                    </ul>
-                </dd>
                 <dt>Shortcuts</dt>
                 <dd>
                     <ul>


### PR DESCRIPTION
This section is dependent on the same css file as of the main website. The main website was changed recently and so news section has become inconsistent.

![Screenshot 2019-05-05 at 1 06 26 AM](https://user-images.githubusercontent.com/40331563/57184031-dbb88000-6ed2-11e9-961a-63ea6dfe44d3.png)
